### PR TITLE
added missing `npm install` to demo code

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ Get the demo running locally:
 
 ``` sh
 git clone git@github.com:NogsMPLS/react-component-styleguide.git
-cd react-component-styleguide/example/
+cd react-component-styleguide/
+npm install
+cd example/
 npm install
 npm start
 ```


### PR DESCRIPTION
If you are checkout out react-component-styleguide freshly, you also need an `npm install` in the project directory itself in order to run the example.
